### PR TITLE
Fix searching for `--compile_args_from=`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -351,13 +351,13 @@ class CMakeToolsIntegration implements vscode.Disposable {
 		const config = vscode.workspace.getConfiguration('clangd');
 		const args = config.get<string[]>('arguments', []);
 
-		const ArgId = args.indexOf('--compile_args_from=');
-		if (ArgId === -1) {
+		const compileArgsFromValue = args.find((value) => value.startsWith('--compile_args_from='));
+		if (compileArgsFromValue === undefined) {
 			this.compileArgsFrom = CompileArgsSource.both;
 			return;
 		}
 
-		const value = args[ArgId].split('=')[1];
+		const value = compileArgsFromValue.split('=')[1];
 		this.compileArgsFrom = value as CompileArgsSource;
 	}
 


### PR DESCRIPTION
Hi,

Thanks for your extensions, which allows using clangd with cmake without needed additional per project configuration even with non-standard cmake.buildDirectory path :)

While using it, I found that adding  `"--compile_args_from=lsp"` to `clangd.arguments` vscode-clangd setting was ignored by the vscode-clangd-cmake extension.
The reason is that indexOf only search full matches and I did not have exactly `--compile_args_from=`.

Replacing with a find instead allow search the first item that starts with `--compile_args_from=` and then get the value afterward.